### PR TITLE
Rename CI job from "Format and Lint" to "Style" for clarity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
 
 jobs:
-  style:
-    name: Format and Lint
+style:
+    name: Style
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/ci.yml` file to rename the `style` job from "Format and Lint" to "Style" for consistency and brevity.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL9-R9): Renamed the `style` job's name from "Format and Lint" to "Style".