### PR TITLE
Add check for go fmt output in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           go-version: '1.24'
 
       - name: Run go fmt
-        run: go fmt ./...
+        run: test -z $(go fmt ./...)
 
   tests:
     name: Tests


### PR DESCRIPTION
This pull request makes a small but important change to the CI workflow configuration in `.github/workflows/ci.yml`. The change modifies the `Run go fmt` step to fail the CI pipeline if any files are not properly formatted.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL22-R22): Updated the `Run go fmt` step to use `test -z $(go fmt ./...)`, ensuring the CI fails if `go fmt` detects unformatted files.