### PR TITLE
Add initial CI/CD workflow configuration for deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,22 @@
+name: cd
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  Deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Build
+        run: ./scripts/buildprod.sh


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for continuous deployment (CD). The workflow is triggered on pushes to the `main` branch and includes steps for checking out the code, setting up the Go environment, and building the production version of the application.

Key changes:

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R1-R22): Introduced a new workflow named `cd` that runs on `ubuntu-latest` and is triggered by pushes to the `main` branch. The workflow includes steps for checking out the repository (`actions/checkout@v4`), setting up Go (`actions/setup-go@v5` with Go version `1.24`), and running the build script (`./scripts/buildprod.sh`).